### PR TITLE
Support Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.6.4",
-        "laravel/framework": "5.3.*|5.4.*",
+        "laravel/framework": "5.3.*|5.4.*|5.5.*",
         "laravel/scout": "^2.0|^3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,12 @@
         "files": [
             "src/helpers.php"
         ]
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Yab\\MySQLScout\\Providers\\MySQLScoutServiceProvider"
+            ]
+        }
     }
 }


### PR DESCRIPTION
Updated the composer.json to allow for Laravel 5.5 And have tested it with both an existing application upgraded to 5.5 and a fresh 5.5 app.

Also included support for Laravel Package autodiscovery feature.