### PR TITLE
Include soft delete option

### DIFF
--- a/src/Engines/MySQLEngine.php
+++ b/src/Engines/MySQLEngine.php
@@ -56,6 +56,10 @@ class MySQLEngine extends Engine
 
         $model = $builder->model;
         $query = $model::whereRaw($whereRawString, $params);
+        
+        if (config('scout.soft_delete')) {
+            $query = $query->withTrashed();
+        }
 
         $result['count'] = $query->count();
 


### PR DESCRIPTION
Allow the inclusion of soft deleted models in the search results based on the config parameter described in the [Laravel docs](https://laravel.com/docs/5.6/scout#soft-deleting).