### PR TITLE
Feature/use mode class references

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.0",
-        "laravel/scout": "^6.0"
+        "laravel/scout": "^7.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "laravel/scout": "^7.1"
     },
     "autoload": {

--- a/config/config.txt
+++ b/config/config.txt
@@ -1,8 +1,8 @@
     'mysql' => [
-        'mode' => 'NATURAL_LANGUAGE',
+        'mode' => Yab\MySQLScout\Engines\Modes\NaturalLanguage::class,
         'model_directories' => [app_path()],
         'min_search_length' => 0,
         'min_fulltext_search_length' => 4,
-        'min_fulltext_search_fallback' => 'LIKE',
+        'min_fulltext_search_fallback' => Yab\MySQLScout\Engines\Modes\Like::class,
         'query_expansion' => false
     ]

--- a/src/Providers/MySQLScoutServiceProvider.php
+++ b/src/Providers/MySQLScoutServiceProvider.php
@@ -42,11 +42,10 @@ class MySQLScoutServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton(ModeContainer::class, function ($app) {
-            $engineNamespace = 'Yab\\MySQLScout\\Engines\\Modes\\';
-            $mode = $engineNamespace.studly_case(strtolower(config('scout.mysql.mode')));
-            $fallbackMode = $engineNamespace.studly_case(strtolower(config('scout.mysql.min_fulltext_search_fallback')));
+            $modeClass = config('scout.mysql.mode');
+            $fallbackModeClass = config('scout.mysql.min_fulltext_search_fallback');
 
-            return new ModeContainer(new $mode(), new $fallbackMode());
+            return new ModeContainer(app($modeClass), app($fallbackModeClass));
         });
     }
 }


### PR DESCRIPTION
I think its more flexible to use class references in config. So you can create your own Mode abstractions and have auto completion (depending on your IDE) in the config file.

BTW: This will not fix https://github.com/worksweet/laravel-scout-mysql-driver/issues/58

Hope it helps.