### PR TITLE
Error gots thrown if a non Model ist in app/ folder

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -94,6 +94,8 @@
                 $classes[] = $class_name;
             }
         }
-
+        if (!isset($classes[0]) {
+            return 'no_class_found_in_file';
+        }
         return $classes[0];
     }


### PR DESCRIPTION
I know it's not the nicest fix but maybe someone comes up with a better solution.

I had my helpers.php file in app/ and an error got thrown cause $classes[0] wasn't set.