### PR TITLE
Add relevance attribute to Models if Mode is FullText compatible

### DIFF
--- a/src/Engines/Modes/Boolean.php
+++ b/src/Engines/Modes/Boolean.php
@@ -20,6 +20,13 @@ class Boolean extends Mode
         return $queryString;
     }
 
+    public function buildSelectColumns(Builder $builder)
+    {
+        $indexFields = implode(',',  $this->modelService->setModel($builder->model)->getFullTextIndexFields());
+
+        return "*, MATCH($indexFields) AGAINST(? IN NATURAL LANGUAGE MODE) AS relevance";
+    }
+
     public function buildParams(Builder $builder)
     {
         $this->whereParams[] = $builder->query;

--- a/src/Engines/Modes/NaturalLanguage.php
+++ b/src/Engines/Modes/NaturalLanguage.php
@@ -25,6 +25,13 @@ class NaturalLanguage extends Mode
         return $queryString;
     }
 
+    public function buildSelectColumns(Builder $builder)
+    {
+        $indexFields = implode(',',  $this->modelService->setModel($builder->model)->getFullTextIndexFields());
+
+        return "*, MATCH($indexFields) AGAINST(? IN NATURAL LANGUAGE MODE) AS relevance";
+    }
+
     public function buildParams(Builder $builder)
     {
         $this->whereParams[] = $builder->query;

--- a/src/Engines/MySQLEngine.php
+++ b/src/Engines/MySQLEngine.php
@@ -4,6 +4,7 @@ namespace Yab\MySQLScout\Engines;
 
 use Yab\MySQLScout\Engines\Modes\ModeContainer;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\Engine;
 
@@ -65,6 +66,9 @@ class MySQLEngine extends Engine
 
         $model = $builder->model;
         $query = $model::whereRaw($whereRawString, $params);
+        if ($mode->isFullText()) {
+            $query = $query->selectRaw(DB::raw($mode->buildSelectColumns($builder)), $params);
+        }
 
         if($builder->callback){
             $query = call_user_func($builder->callback, $query, $this);


### PR DESCRIPTION
By modifiyng the fields in the select we can add the relevance and then add it to the models attributes in the collection results.

This will allow us to make our business on PHP part to filter on relevance or to merge many collections (obtained as the search result on different Models) and then order the merge by relevance ... 