### PR TITLE
prefixed fields with table name in like and like expanded modes

### DIFF
--- a/src/Engines/Modes/Like.php
+++ b/src/Engines/Modes/Like.php
@@ -11,6 +11,8 @@ class Like extends Mode
 
     public function buildWhereRawString(Builder $builder)
     {
+        $table = $builder->model->getTable();
+        
         $queryString = '';
 
         $this->fields = $this->modelService->setModel($builder->model)->getSearchableFields();
@@ -20,7 +22,7 @@ class Like extends Mode
         $queryString .= '(';
 
         foreach ($this->fields as $field) {
-            $queryString .= "`$field` LIKE ? OR ";
+            $queryString .= "`$table`.`$field` LIKE ? OR ";
         }
 
         $queryString = trim($queryString, 'OR ');

--- a/src/Engines/Modes/LikeExpanded.php
+++ b/src/Engines/Modes/LikeExpanded.php
@@ -11,6 +11,8 @@ class LikeExpanded extends Mode
 
     public function buildWhereRawString(Builder $builder)
     {
+        $table = $builder->model->getTable();
+        
         $queryString = '';
 
         $this->fields = $this->modelService->setModel($builder->model)->getSearchableFields();
@@ -23,14 +25,14 @@ class LikeExpanded extends Mode
 
         foreach ($this->fields as $field) {
             foreach ($words as $word) {
-                $queryString .= "`$field` LIKE ? OR ";
+                $queryString .= "`$table`.`$field` LIKE ? OR ";
             }
         }
 
         $queryString = trim($queryString, 'OR ');
         $queryString .= ')';
 
-        return$queryString;
+        return $queryString;
     }
 
     public function buildParams(Builder $builder)


### PR DESCRIPTION
In our application for a given model we use a global scope that performs a join. If we search on that model (with our global scope active) we get a mysql error about ambiguous id field. This was fixed by prepending the table name when building the raw where string.