### PR TITLE
Escape SQL sentences to avoid conflicts with reserved words

### DIFF
--- a/src/Services/IndexService.php
+++ b/src/Services/IndexService.php
@@ -88,7 +88,7 @@ class IndexService
         $indexName = $this->modelService->indexName;
 
         return !empty(DB::connection($this->modelService->connectionName)->
-        select("SHOW INDEX FROM `$tableName` WHERE Key_name = ?", [$indexName]));
+        select("SHOW INDEX FROM `$tableName` WHERE `Key_name` = ?", [$indexName]));
     }
 
     protected function indexNeedsUpdate()
@@ -105,7 +105,7 @@ class IndexService
         $tableName = $this->modelService->tablePrefixedName;
 
         $index = DB::connection($this->modelService->connectionName)->
-        select("SHOW INDEX FROM `$tableName` WHERE Key_name = ?", [$indexName]);
+        select("SHOW INDEX FROM `$tableName` WHERE `Key_name` = ?", [$indexName]);
 
         $indexFields = [];
 

--- a/src/Services/IndexService.php
+++ b/src/Services/IndexService.php
@@ -77,7 +77,7 @@ class IndexService
         }
 
         DB::connection($this->modelService->connectionName)
-            ->statement("CREATE FULLTEXT INDEX $indexName ON $tableName ($indexFields)");
+            ->statement("CREATE FULLTEXT INDEX `$indexName` ON `$tableName` ($indexFields)");
 
         event(new Events\ModelIndexCreated($indexName, $indexFields));
     }
@@ -88,7 +88,7 @@ class IndexService
         $indexName = $this->modelService->indexName;
 
         return !empty(DB::connection($this->modelService->connectionName)->
-        select("SHOW INDEX FROM $tableName WHERE Key_name = ?", [$indexName]));
+        select("SHOW INDEX FROM `$tableName` WHERE Key_name = ?", [$indexName]));
     }
 
     protected function indexNeedsUpdate()
@@ -105,7 +105,7 @@ class IndexService
         $tableName = $this->modelService->tablePrefixedName;
 
         $index = DB::connection($this->modelService->connectionName)->
-        select("SHOW INDEX FROM $tableName WHERE Key_name = ?", [$indexName]);
+        select("SHOW INDEX FROM `$tableName` WHERE Key_name = ?", [$indexName]);
 
         $indexFields = [];
 
@@ -135,7 +135,7 @@ class IndexService
 
         if ($this->indexAlreadyExists()) {
             DB::connection($this->modelService->connectionName)
-                ->statement("ALTER TABLE $tableName DROP INDEX $indexName");
+                ->statement("ALTER TABLE `$tableName` DROP INDEX `$indexName`");
             event(new Events\ModelIndexDropped($this->modelService->indexName));
         }
     }

--- a/src/Services/ModelService.php
+++ b/src/Services/ModelService.php
@@ -48,7 +48,7 @@ class ModelService
         foreach ($searchableFields as $searchableField) {
 
             //@TODO cache this.
-            $sql = "SHOW FIELDS FROM `$this->tablePrefixedName` where Field = ?";
+            $sql = "SHOW FIELDS FROM `$this->tablePrefixedName` where `Field` = ?";
             $column = DB::connection($this->connectionName)->select($sql, [$searchableField]);
 
             if (!isset($column[0])) {

--- a/src/Services/ModelService.php
+++ b/src/Services/ModelService.php
@@ -48,7 +48,7 @@ class ModelService
         foreach ($searchableFields as $searchableField) {
 
             //@TODO cache this.
-            $sql = "SHOW FIELDS FROM $this->tablePrefixedName where Field = ?";
+            $sql = "SHOW FIELDS FROM `$this->tablePrefixedName` where Field = ?";
             $column = DB::connection($this->connectionName)->select($sql, [$searchableField]);
 
             if (!isset($column[0])) {


### PR DESCRIPTION
I found this issue when I try to use the Searchable trait in a table named 'groups' in MySQL 8.0. I think is better to have escaped names escaped to prevent this.

Thanks!