### PR TITLE
Allow NOT NULL logic in where clauses. 

### DIFF
--- a/src/Engines/Modes/Mode.php
+++ b/src/Engines/Modes/Mode.php
@@ -42,7 +42,12 @@ abstract class Mode
                 $this->whereParams[$field] = $value;
                 $queryString .= "$field $operator ? AND ";
             } else {
-                $queryString .= "$field IS NULL AND ";
+                
+                if($operator === '!='){
+                    $queryString .= "$field IS NOT NULL AND ";
+                }else{
+                    $queryString .= "$field IS NULL AND ";
+                }
             }
         }
 


### PR DESCRIPTION
Just a minor change allows you to use

`->where('field', null);`

and

`->where('field !=', null);`

